### PR TITLE
Fix array OOM error

### DIFF
--- a/game4.10/Source/YMap.h
+++ b/game4.10/Source/YMap.h
@@ -8,8 +8,7 @@ namespace game_framework {
 
 	public:
 		
-		YMap() {
-			mymap[9][5] = { 0 };
+		YMap() :mymap{ 0 } {
 			/*mymap[7][4] = 1;
 			mymap[7][3] = 1;
 			mymap[7][2] = 1;


### PR DESCRIPTION
The maximum index of array is mymap[8][4]. 
Thus, access mymap[9][5] could cause Out-Of-Memeory error.
This is **Undefined Behavior**.
Use initializer instead.