### PR TITLE
修正豌豆及殭屍數量為偶數時的非預期行為

### DIFF
--- a/game4.10/Source/YPlants.h
+++ b/game4.10/Source/YPlants.h
@@ -146,6 +146,7 @@ namespace game_framework {
 	public:
 		YPeaShooter(int x, int y)
 		{
+			delay = 30;
 			this->x = x + 20;
 			this->y = y + 20;
 			blood = 5;
@@ -165,7 +166,7 @@ namespace game_framework {
 		void OnMove()
 		{
 			peashooter_animation.OnMove();
-			static int delay = 30;
+			
 			if (delay == 0) {
 				fireBullet();
 				delay = 80;
@@ -249,6 +250,7 @@ namespace game_framework {
 		int blood;
 		std::vector<shared_ptr<YPeaShooterBullet>> bullets_vector;
 		CAnimation peashooter_animation;
+		int delay;
 	};
 }
 

--- a/game4.10/Source/YZombies.h
+++ b/game4.10/Source/YZombies.h
@@ -78,7 +78,7 @@ namespace game_framework {
 		}
 
 		void OnMove(std::string mode) {
-			static int delay;
+
 		
 			if (mode == "attack") {
 				zombie_attack_animation.OnMove();
@@ -165,6 +165,7 @@ namespace game_framework {
 		CAnimation zombie_die_animation_head;
 		int zombie_die_delay_time = 200;
 		int attack_power = 1;
+		int delay = 0;
 	};
 
 


### PR DESCRIPTION
delay應為每個豌豆都不一樣的變數
(每個豌豆產生的時間不一樣，發射第一顆的時間應該也不一樣)
殭屍的delay也是一樣概念
當用static宣告時，整個程式只會有一個delay
代表所有豌豆共享一個delay，才會有這種奇怪的現象

建議沒事不要用static